### PR TITLE
Only include necessary files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-examples
-node_modules
-.DS_*
-npm-debug.*
-*.sublime*
-thumb

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
   "bugs": {
     "url": "https://github.com/turingou/player/issues"
   },
+  "files": [
+    "bin",
+    "index.js",
+    "libs"
+  ],
   "dependencies": {
     "async": "^0.9.0",
     "home": "^0.1.3",


### PR DESCRIPTION
Don't include examples etc. on `npm install`. A little cleaner to define in `package.json`.